### PR TITLE
Fix screen in Docker

### DIFF
--- a/root/defaults/screenrc
+++ b/root/defaults/screenrc
@@ -1,0 +1,4 @@
+# we do not want the width to change to 80 characters on startup:
+termcap xterm 'is=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;4;6l'
+terminfo xterm 'is=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;4;6l'
+termcapinfo xterm 'is=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;4;6l'

--- a/root/defaults/screenrc
+++ b/root/defaults/screenrc
@@ -2,3 +2,22 @@
 termcap xterm 'is=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;4;6l'
 terminfo xterm 'is=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;4;6l'
 termcapinfo xterm 'is=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;4;6l'
+
+# 256 colors
+attrcolor b ".I"
+termcapinfo xterm 'Co#256:AB=\E[48;5;%dm:AF=\E[38;5;%dm'
+defbce on
+
+# huge scrollback buffer
+defscrollback 5000
+
+#remove some stupid / dangerous key bindings
+bind ^k
+#bind L
+bind ^\
+#make them better
+bind \\ quit
+bind K kill
+bind I login on
+bind O login off
+bind } history

--- a/root/etc/cont-init.d/98-irssi-autodl
+++ b/root/etc/cont-init.d/98-irssi-autodl
@@ -16,8 +16,7 @@ if [ ! -e /usr/bin/irssi ]; then
     perl-xml-libxml \
     perl-digest-sha1 \
     perl-json \
-    perl-json-xs \
-    tmux
+    perl-json-xs
   if [ ! -d /config/.irssi ]; then
     mkdir -p /config/.irssi
     echo 'load perl' > /config/.irssi/startup
@@ -75,6 +74,11 @@ elif [ -d /config/plugins/autodl-irssi ]; then
   echo "**** autodl-irssi rutorrent plugin found - running update ****"
   git -C /config/plugins/autodl-irssi pull --ff-only
 fi
+
+# configure screen (to access irssi inside container)
+# docker exec -it rutorrent screen -r irssi
+[[ ! -f /config/screenrc ]] && \
+  cp /defaults/screenrc /config/screenrc
 
 # unset generated password
 unset adlpass

--- a/root/etc/cont-init.d/98-irssi-autodl
+++ b/root/etc/cont-init.d/98-irssi-autodl
@@ -16,7 +16,8 @@ if [ ! -e /usr/bin/irssi ]; then
     perl-xml-libxml \
     perl-digest-sha1 \
     perl-json \
-    perl-json-xs
+    perl-json-xs \
+    tmux
   if [ ! -d /config/.irssi ]; then
     mkdir -p /config/.irssi
     echo 'load perl' > /config/.irssi/startup

--- a/root/etc/cont-init.d/98-irssi-autodl
+++ b/root/etc/cont-init.d/98-irssi-autodl
@@ -3,6 +3,10 @@
 # generate random password for initial plug-in setup
 adlpass=$(openssl rand -base64 20)
 
+# configure screen to more than 80 columns
+[[ ! -f /config/screenrc ]] && \
+  cp /defaults/screenrc /config/screenrc
+
 # install irssi with perl dependancies and php7-sockets
 if [ ! -e /usr/bin/irssi ]; then
   echo "**** irssi not found - installing ****"
@@ -74,11 +78,6 @@ elif [ -d /config/plugins/autodl-irssi ]; then
   echo "**** autodl-irssi rutorrent plugin found - running update ****"
   git -C /config/plugins/autodl-irssi pull --ff-only
 fi
-
-# configure screen (to access irssi inside container)
-# docker exec -it rutorrent screen -r irssi
-[[ ! -f /config/screenrc ]] && \
-  cp /defaults/screenrc /config/screenrc
 
 # unset generated password
 unset adlpass

--- a/root/etc/services.d/irssi/run
+++ b/root/etc/services.d/irssi/run
@@ -9,9 +9,7 @@ trap _term SIGTERM
 
 export HOME="/config"
 #screen -D -m -S irssi s6-setuidgid abc /usr/bin/irssi --home /config/.irssi &
-tmux -2 -d new-window \
-  -n irssi \
-  -s autodl-irssi \
+tmux -2 -c \
   "s6-setuidgid abc /usr/bin/irssi --home /config/.irssi" &
 
 wait

--- a/root/etc/services.d/irssi/run
+++ b/root/etc/services.d/irssi/run
@@ -8,9 +8,9 @@ _term() {
 trap _term SIGTERM
 
 export HOME="/config"
-export COLUMNS="190"
-screen -AaDmS irssi \
-  -T screen-256color \
-  s6-setuidgid abc /usr/bin/irssi --home /config/.irssi &
+screen -c /config/screenrc \
+  -D -m -S irssi \
+  s6-setuidgid abc \
+  /usr/bin/irssi --home /config/.irssi &
 
 wait

--- a/root/etc/services.d/irssi/run
+++ b/root/etc/services.d/irssi/run
@@ -8,8 +8,8 @@ _term() {
 trap _term SIGTERM
 
 export HOME="/config"
-#screen -D -m -S irssi s6-setuidgid abc /usr/bin/irssi --home /config/.irssi &
-tmux -2 -c \
-  "s6-setuidgid abc /usr/bin/irssi --home /config/.irssi" &
+screen -OdmS irssi \
+  -T screen-256color \
+  s6-setuidgid abc /usr/bin/irssi --home /config/.irssi &
 
 wait

--- a/root/etc/services.d/irssi/run
+++ b/root/etc/services.d/irssi/run
@@ -8,8 +8,8 @@ _term() {
 trap _term SIGTERM
 
 export HOME="/config"
-screen -OdmS irssi \
-  -T screen-256color \
+screen -OaDmS irssi \
+  -T xterm-256color \
   s6-setuidgid abc /usr/bin/irssi --home /config/.irssi &
 
 wait

--- a/root/etc/services.d/irssi/run
+++ b/root/etc/services.d/irssi/run
@@ -8,8 +8,10 @@ _term() {
 trap _term SIGTERM
 
 export HOME="/config"
-screen -D -m -S irssi \
-  s6-setuidgid abc \
-  /usr/bin/irssi --home /config/.irssi &
+#screen -D -m -S irssi s6-setuidgid abc /usr/bin/irssi --home /config/.irssi &
+tmux -2 -d new-window \
+  -n irssi \
+  -s autodl-irssi \
+  "s6-setuidgid abc /usr/bin/irssi --home /config/.irssi" &
 
 wait

--- a/root/etc/services.d/irssi/run
+++ b/root/etc/services.d/irssi/run
@@ -8,8 +8,9 @@ _term() {
 trap _term SIGTERM
 
 export HOME="/config"
-screen -OaDmS irssi \
-  -T xterm-256color \
+export COLUMNS="190"
+screen -AaDmS irssi \
+  -T screen-256color \
   s6-setuidgid abc /usr/bin/irssi --home /config/.irssi &
 
 wait


### PR DESCRIPTION
Fixes screen for irssi to use more than 80 columns

Connect to irssi
`docker exec -it rutorrent screen -r irssi`